### PR TITLE
Add "schedule" command for chat channels.  & Fixes issue #33.

### DIFF
--- a/bot_text.json
+++ b/bot_text.json
@@ -14,5 +14,8 @@
 		"schedule": "A full schedule of upcoming games can be found at <https://goo.gl/TQ8GoH>\n\nThe schedule should be shown in your time zone, but you can verify this by checking the menu in the top right.\n\n*If the schedule appears to be blank, we may not have any games currently planned. Check back soon to see if we've added any!*",
 		"twitch": "All our games are streamed over at our Twitch channel: <https://twitch.tv/pubgreddit>\n\nTwitch subscribers get access to #super-secret-sub-club, where passwords for custom games are posted before being announced publicly. Any funds raised through subscriptions will go into future tournaments! Once you've subscribed just make sure your Twitch account is linked to your Discord account and you should get the role!",
 		"forms": "The game modes we play are usually taken from this list, which we continue to expand with new modes: <https://goo.gl/JU1ds1> You can suggest new modes using this form: <https://goo.gl/forms/b8AZGpSQpvkj1suj1>\n\nIf you have experience streaming games on Twitch (with a solid internet connection and a PC good enough to handle it), and have the availability to host at least approximately once per week, please let us know by filling out this form: <https://goo.gl/forms/H1QrCeS2KZ1JB8IE3>"
+	},
+	"chatResponses": {
+		"schedule": "A full schedule of upcoming games can be found at <https://goo.gl/TQ8GoH>\n\nThe schedule should be shown in your time zone, but you can verify this by checking the menu in the top right.\n\n*If the schedule appears to be blank, we may not have any games currently planned. Check back soon to see if we've added any!*"
 	}
 }

--- a/bot_text.json
+++ b/bot_text.json
@@ -2,7 +2,7 @@
 	"helpText": [
 		"`$squadvote <squad size 1> <squad size 2> ...` - Post a vote for squad size for the next game, defaults to 1, 2, 4, and 8. `$squadvote all` will do every size between 1 and 10. Automatically changes voice channel sizes to winning vote. e.g. `$squadvote 1 2 3 4`",
 		"`$regionvote` - Post a vote for the region for this session's custom games.",
-		"`$password <password> <minutes>` - Post a countdown to the <password> release of <minutes> minutes. Automatically posts password to #mods and #super-secret-sub-club.",
+		"`$password <password> (minutes)` - Post a countdown to the <password> release of <minutes> minutes. Automatically posts password to #mods and #super-secret-sub-club. Minutes optional, default is 2 minutes.",
 		"`$setvoicelimit <size>` - Change all customs voice channels to <size>.",
 		"`$clear <number>` - Remove <number> of CustomsBot messages from #custom-games. `$clear all` will remove all CustomsBot messages.",
 		"`$fullvote` - Start a vote for every game mode, for use in the 'We'll do it live' game mode."

--- a/bot_text.json
+++ b/bot_text.json
@@ -16,6 +16,6 @@
 		"forms": "The game modes we play are usually taken from this list, which we continue to expand with new modes: <https://goo.gl/JU1ds1> You can suggest new modes using this form: <https://goo.gl/forms/b8AZGpSQpvkj1suj1>\n\nIf you have experience streaming games on Twitch (with a solid internet connection and a PC good enough to handle it), and have the availability to host at least approximately once per week, please let us know by filling out this form: <https://goo.gl/forms/H1QrCeS2KZ1JB8IE3>"
 	},
 	"chatResponses": {
-		"schedule": "A full schedule of upcoming games can be found at <https://goo.gl/TQ8GoH>\n\nThe schedule should be shown in your time zone, but you can verify this by checking the menu in the top right.\n\n*If the schedule appears to be blank, we may not have any games currently planned. Check back soon to see if we've added any!*"
+		"schedule": "A full schedule of upcoming games can be found at <https://goo.gl/TQ8GoH>. *If there's nothing on the schedule, nothing is scheduled.*"
 	}
 }

--- a/config.json.in
+++ b/config.json.in
@@ -6,6 +6,7 @@
 	"channels": {
 		"hoster": "ID for the custom hoster channel",
 		"customgames": "ID for the custom games channel",
+		"customchat": "ID for the custom chat channel",
 		"mods": "ID for the mods channel",
 		"sssc": "ID for the subscriber channel"
 	},

--- a/customsbot.py
+++ b/customsbot.py
@@ -57,6 +57,12 @@ def get_custom_games():
 
     return customs_channel
 
+def get_custom_chat():
+    """Returns #custom-chat-lfg object"""
+    customchat_channel = discord_client.get_channel(config_data["channels"]["customchat"])
+
+    return customschat_channel
+
 def log_command(message_object, text, error=False):
     """Whenever a command is sent, log it to today's log file"""
     current_folder = os.path.dirname(__file__)
@@ -573,6 +579,14 @@ async def help(ctx):
                                description=help_text)
 
     await discord_client.send_message(hoster_channel, embed=help_embed)
+
+@discord_client.command(name='schedule', pass_context=True)
+async def schedule(ctx):
+    schedule_text = text_data["chatResponses"]["schedule"]
+    message_channel = ctx.message.channel
+    await discord_client.delete_message(ctx.message)
+    await discord_client.send_message(message_channel, content=schedule_text)
+    return
 
 @discord_client.event
 async def on_command_error(error, ctx):

--- a/customsbot.py
+++ b/customsbot.py
@@ -584,9 +584,9 @@ async def help(ctx):
 async def schedule(ctx):
     schedule_text = text_data["chatResponses"]["schedule"]
     message_channel = ctx.message.channel
-    await discord_client.delete_message(ctx.message)
     await discord_client.send_message(message_channel, content=schedule_text)
-    return
+    await discord_client.delete_message(ctx.message)
+    log_command(ctx.message, "Schedule info posted")
 
 @discord_client.event
 async def on_command_error(error, ctx):

--- a/customsbot.py
+++ b/customsbot.py
@@ -343,7 +343,7 @@ async def password_countdown(ctx, password, *args):
     pinging @here in SSSC only.
 
     Hoster must specify a password, and may optionally specify the number
-    of minutes until the password is released. Defaults to 5 minutes.
+    of minutes until the password is released. Defaults to 2 minutes.
     """
     message_channel = ctx.message.channel
 


### PR DESCRIPTION
Adds a "schedule" command and posts shortened message to channel. Requires "Manage Messages" permission to delete command message (but posts anyway without it).